### PR TITLE
Add Next.js boilerplate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 # codex-sample
+
+This repository now contains a minimal [Next.js](https://nextjs.org/) boilerplate.
+
+## Getting Started
+
+1. Install dependencies (requires internet access):
+   ```bash
+   npm install
+   ```
+2. Start the development server:
+   ```bash
+   npm run dev
+   ```
+
+The default page is located at `pages/index.js`.

--- a/package.json
+++ b/package.json
@@ -1,0 +1,15 @@
+{
+  "name": "codex-sample-nextjs",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "14.2.4",
+    "react": "18.3.1",
+    "react-dom": "18.3.1"
+  }
+}

--- a/pages/index.js
+++ b/pages/index.js
@@ -1,0 +1,7 @@
+export default function Home() {
+  return (
+    <div>
+      <h1>Welcome to Next.js!</h1>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- set up a minimal Next.js project
- add example home page
- document how to install dependencies and run the dev server

## Testing
- `npm install` *(fails: 403 Forbidden due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_6886ebfa71ac8320857b66a3f10bb889